### PR TITLE
Add Behind my Cloud feed #1 - 
Removes Behind my Cloud feed


### DIFF
--- a/index.html
+++ b/index.html
@@ -56,6 +56,10 @@
                     <h3><a href="https://youtube.com/@fboucheros" target="_blank">Frank Boucher</a></h3>
                     <div class="rss" id="feed-yt-fboucheros">Loading...</div>
                 </div>
+                <div class="feed">
+                    <h3><a href="https://youtube.com/@behindmycloud" target="_blank">Behind my Cloud</a></h3>
+                    <div class="rss" id="feed-yt-behindmycloud">Loading...</div>
+                </div>
             </div>
             <div class="content-column">
                 <h2>French Content</h2>

--- a/script.js
+++ b/script.js
@@ -35,6 +35,11 @@ const feeds = [
         id: 'feed-yt-cloud', 
         url: 'https://www.youtube.com/feeds/videos.xml?channel_id=UChFOuhUf12hIVEdcnaSUNzA', 
         type: 'yt' 
+    },
+    {
+        id: 'feed-yt-behindmycloud',
+        url: 'https://www.youtube.com/feeds/videos.xml?channel_id=UCzX9-dTqz-kG5q1-uys_NGw', 
+        type: 'yt' 
     }
 ];
 


### PR DESCRIPTION

Removes the "Behind my Cloud" YouTube feed from the website.

The feed is no longer relevant to the site's content.
